### PR TITLE
remove 2008r2/8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ This cookbook configures Windows firewall rules.
 
 ### Platforms
 
-- Windows 7, 8, 8.1, 10
-- Windows Server 2008 R2
+- Windows 8, 8.1, 10
 - Windows Server 2012 (R1, R2)
 - Windows Server 2016
 


### PR DESCRIPTION
Signed-off-by: Tor Magnus Rakvåg <tor.magnus@outlook.com>

### Description

2008r2 and windows 7 don't support the `-NetFirewall` cmdlets or the underlying APIs.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
